### PR TITLE
Support for Python 3.12 - Linux py

### DIFF
--- a/Linux/beroot/modules/sudo/sudo_list.py
+++ b/Linux/beroot/modules/sudo/sudo_list.py
@@ -74,13 +74,13 @@ class SudoList(object):
 
             pattern = re.compile(
                 r"\s*" +
-                "runasusers:\s*(?P<runasusers>\w*)" +
-                "\s*" +
-                "(runasgroups:\s*(?P<runasgroups>\w*))*" +
-                "\s*" +
-                "(options:\s*(?P<options>[\!\w]*))*" +
-                "\s*" +
-                "(commands:\s*(?P<commands>.*))*",
+                "runasusers:\\s*(?P<runasusers>\\w*)" +
+                "\\s*" +
+                "(runasgroups:\\s*(?P<runasgroups>\\w*))*" +
+                "\\s*" +
+                "(options:\\s*(?P<options>[\\!\\w]*))*" +
+                "\\s*" +
+                "(commands:\\s*(?P<commands>.*))*",
                 re.DOTALL
             )
             m = pattern.search(sudo_rule)


### PR DESCRIPTION
It solves the following warnings coming from Python3.12:
```python
/usr/share/beroot/Linux/beroot/modules/sudo/sudo_list.py:77: SyntaxWarning: invalid escape sequence '\s'
  "runasusers:\s*(?P<runasusers>\w*)" +
/usr/share/beroot/Linux/beroot/modules/sudo/sudo_list.py:78: SyntaxWarning: invalid escape sequence '\s'
  "\s*" +
/usr/share/beroot/Linux/beroot/modules/sudo/sudo_list.py:79: SyntaxWarning: invalid escape sequence '\s'
  "(runasgroups:\s*(?P<runasgroups>\w*))*" +
/usr/share/beroot/Linux/beroot/modules/sudo/sudo_list.py:80: SyntaxWarning: invalid escape sequence '\s'
  "\s*" +
/usr/share/beroot/Linux/beroot/modules/sudo/sudo_list.py:81: SyntaxWarning: invalid escape sequence '\s'
  "(options:\s*(?P<options>[\!\w]*))*" +
/usr/share/beroot/Linux/beroot/modules/sudo/sudo_list.py:82: SyntaxWarning: invalid escape sequence '\s'
  "\s*" +
/usr/share/beroot/Linux/beroot/modules/sudo/sudo_list.py:83: SyntaxWarning: invalid escape sequence '\s'
  "(commands:\s*(?P<commands>.*))*",
```